### PR TITLE
fix: NPCs that cannot use normal rooms being able to be "prioritized", preventing town NPC spawns.

### DIFF
--- a/Common/SpawningDetours.cs
+++ b/Common/SpawningDetours.cs
@@ -1,0 +1,64 @@
+﻿using HousingAPI.Content;
+using HousingAPI.Utilities;
+using MonoMod.Cil;
+
+#nullable enable
+
+namespace HousingAPI.Common;
+
+internal class SpawningDetours : ILoadable
+{
+	public void Load(Mod mod)
+    {
+		IL_WorldGen.UpdateWorld_Inner += FixSpecialHomelessNpcsPreventingTownNpcSpawns;
+    }
+
+    public void Unload() { }
+
+	private static void FixSpecialHomelessNpcsPreventingTownNpcSpawns(ILContext ctx)
+	{
+		var il = new ILCursor(ctx);
+
+		// Match parts of of '!(Main.npc[i].ModNPC?.TownNPCStayingHomeless)) ?? true)' short-circuit.
+		ILLabel? continueLabel = null;
+		il.GotoNext(
+			MoveType.After,
+			i => i.MatchCall(typeof(ModNPC), $"get_{nameof(ModNPC.TownNPCStayingHomeless)}"),
+			i => i.MatchNewobj(typeof(bool?))
+		);
+		il.GotoNext(
+			MoveType.After,
+			i => i.MatchCall(typeof(bool?), $"GetValueOrDefault"),
+			i => i.MatchBrtrue(out continueLabel)
+		);
+
+		// Match 'prioritizedTownNPCType = Main.npc[i].type;'.
+		int iIndex = -1;
+		il.GotoNext(
+			MoveType.Before,
+			i => i.MatchLdsfld(typeof(Main), nameof(Main.npc)),
+			i => i.MatchLdloc(out iIndex),
+			i => i.MatchLdelemRef(),
+			i => i.MatchLdfld(typeof(NPC), nameof(NPC.type)),
+			i => i.MatchStsfld(typeof(WorldGen), nameof(WorldGen.prioritizedTownNPCType))
+		);
+
+		// Just in case branching semantics differ between TML builds.
+		ILUtils.HijackIncomingLabels(il);
+
+		il.EmitLdloc(iIndex);
+		il.EmitDelegate(AllowPrioritizingHomelessNpc);
+		il.EmitBrfalse(continueLabel!);
+	}
+
+	private static bool AllowPrioritizingHomelessNpc(int npcIndex)
+	{
+		// Do not allow NPCs with special requirements to hog normal rooms, preventing town NPC spawns in the process.
+		if (Main.npc[npcIndex] is NPC npc && !VanillaRoom.AllowsNPC(npc.type))
+		{
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/Content/VanillaRoom.cs
+++ b/Content/VanillaRoom.cs
@@ -106,4 +106,9 @@ public sealed class VanillaRoom : ModRoomType
 			t.ScoreRoom(ref score, ignoreType, npcType);
 		}
 	}
+
+	internal static bool AllowsNPC(int npcType)
+	{
+		return Instance.AllowNPC(npcType);
+	}
 }

--- a/Utilities/ILUtils.cs
+++ b/Utilities/ILUtils.cs
@@ -1,0 +1,25 @@
+﻿using System.Linq;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
+
+namespace HousingAPI.Utilities;
+
+internal static class ILUtils
+{
+	/// <summary>
+	/// When there are labels pointing to the next instruction, inserts a no-op, redirects labels to it, and steps after it.
+	/// </summary>
+	public static ILCursor HijackIncomingLabels(ILCursor cursor)
+	{
+		ILLabel[] incomingLabels = cursor.IncomingLabels.ToArray();
+
+		cursor.Emit(OpCodes.Nop);
+
+		foreach (ILLabel incomingLabel in incomingLabels)
+		{
+			incomingLabel.Target = cursor.Prev;
+		}
+
+		return cursor;
+	}
+}


### PR DESCRIPTION
﻿### Link Issues
Resolves Path-of-Terraria/PathOfTerraria#1226.

### Description of Work
This fixes NPCs that cannot use normal rooms being able to be "prioritized" by vanilla code, preventing all town NPC spawns until they do find a room. This is the root cause of PoT's Garrick NPC spawning issue.